### PR TITLE
Fix the handling of the --version flag. Fixes #1

### DIFF
--- a/source/commandr/parser.d
+++ b/source/commandr/parser.d
@@ -42,15 +42,7 @@ private import core.stdc.stdlib;
  */
 public ProgramArgs parse(Program program, ref string[] args, HelpOutput helpConfig = HelpOutput.init) {
     try {
-        auto res = parseArgs(program, args, helpConfig);
-
-        if (res.flag("version")) {
-            writeln(program.version_);
-            exit(0);
-            assert(0);
-        }
-
-        return res;
+        return parseArgs(program, args, helpConfig);
     } catch(InvalidArgumentsException e) {
         stderr.writeln("Error: ", e.msg);
         program.printUsage(helpConfig);
@@ -199,6 +191,11 @@ private ProgramArgs parseArgs(
 
     if (result.flag("help")) {
         program.printHelp(helpConfig);
+        exit(0);
+    }
+
+    if (result.flag("version")) {
+        writeln(program.version_);
         exit(0);
     }
 


### PR DESCRIPTION
When a program has mandatory arguments, the --version flag is not
handled correctly: an error message complaining about missing arguments
is printed. To fix this, the --version flag has to be handled the same way
as the --help flag.