### PR TITLE
Allow '-' in long option name

### DIFF
--- a/source/commandr/program.d
+++ b/source/commandr/program.d
@@ -347,6 +347,9 @@ public class Command {
             throw new InvalidProgramException("name cannot be empty");
         }
 
+        if (name[0] == '-')
+            throw new InvalidProgramException("invalid name '%s' -- cannot begin with '-'".format(name));
+
         if (!name.all!(c => isAlphaNum(c) || c == '_' || c == '-')()) {
             throw new InvalidProgramException("invalid name '%s' passed".format(name));
         }

--- a/source/commandr/program.d
+++ b/source/commandr/program.d
@@ -347,7 +347,7 @@ public class Command {
             throw new InvalidProgramException("name cannot be empty");
         }
 
-        if (!name.all!(c => isAlphaNum(c) || c == '_')()) {
+        if (!name.all!(c => isAlphaNum(c) || c == '_' || c == '-')()) {
             throw new InvalidProgramException("invalid name '%s' passed".format(name));
         }
 


### PR DESCRIPTION
This change allows long options with dashes in name.
Fixes #10 