### PR TITLE
Save unparsed (rest) args on result

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ commandr-test-*
 *.lst
 /commandr
 source/app.d
+libcommandr.a
+*.sw[npo]

--- a/source/commandr/args.d
+++ b/source/commandr/args.d
@@ -62,6 +62,7 @@ public class ProgramArgs {
         int[string] _flags;
         string[][string] _options;
         string[][string] _args;
+        string[] _args_rest;
         ProgramArgs _parent;
         ProgramArgs _command;
     }
@@ -222,6 +223,27 @@ public class ProgramArgs {
     /// ditto
     alias args = argAll;
 
+    /**
+     * Rest (unparsed) arguments.
+     *
+     * Useful, if you need to access unparsed arguments,
+     * usually supplied after '--'.
+     *
+     * Returns:
+     *   array of arguments that were not handled by parser
+     *
+     * Examples:
+     * ---
+     * auto args = ["my-command", "--opt", "arg", "--", "other-arg", "o-arg"];
+     * auto res = parse(args);
+     *
+     * // Not we can access unparsed args as res.argsRest
+     * assert(res.argsRest == ["other-arg", "o-arg"])
+     * ---
+     */
+    public string[] argsRest() {
+        return _args_rest;
+    }
 
     /**
      * Gets subcommand arguments.

--- a/source/commandr/parser.d
+++ b/source/commandr/parser.d
@@ -189,6 +189,9 @@ private ProgramArgs parseArgs(
         }
     }
 
+    if (args.length > 0)
+        result._args_rest = args.dup;
+
     if (result.flag("help")) {
         program.printHelp(helpConfig);
         exit(0);
@@ -527,6 +530,7 @@ unittest {
                 .defaultValue("reee"))
             .parseArgs(args);
     assert(a.args("test") == ["reee"]);
+    assert(a.argsRest == ["bar"]);
     assert(args == ["bar"]);
 }
 
@@ -576,6 +580,7 @@ unittest {
     assert(a.args("test") == ["cccc"]);
     assert(a.command !is null);
     assert(a.command.name == "a");
+    assert(a.command.argsRest == ["c"]);
     assert(args == ["c"]);
 
     assertThrown!InvalidArgumentsException(


### PR DESCRIPTION
With this change it is possible to access unparsed (rest) arguments via ProgramArgs instance.
This is needed, because in case of complex programs, the code that handles one of subcommands usualy does not have access to the original args array, thus it is good idea to store unparsed arguments on ProgramArgs instance.

This is usefule in cases, when we have program that has subcommand that has some options and have to pass unparsed arguments to some other program directly (for example if we build some kind of wrapper for some other program)